### PR TITLE
Remove Outlearn; website shutting down on May, 20 2016

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@
 * [hack.guides()](http://tutorials.pluralsight.com/)
 * [Aquent Gymnasium](http://gymnasium.aquent.com/)
 * [Codevolve](https://www.codevolve.com/)
-* [Outlearn](http://www.outlearn.com/)
 
 ####Trading:
 * [FX Academy](http://www.fxacademy.com/)


### PR DESCRIPTION
Got an email from them yesterday about the website shutting down in 2 weeks